### PR TITLE
Upgrade AWS CLI and Terraform Versions in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM --platform=linux/amd64 amazon/aws-cli:2.9.1
+FROM --platform=linux/amd64 amazon/aws-cli:2.24.1
 
-ENV TERRAFORM_VERSION=1.3.5
+ENV TERRAFORM_VERSION=1.11.3
 
 VOLUME ["/work"]
 


### PR DESCRIPTION
This Pull Request updates the Dockerfile in the [docker-terraform](https://github.com/dhruvguptaTTN/docker-terraform) repository to use newer versions of the AWS CLI and Terraform for enhanced compatibility and feature support.

Changes made in: Dockerfile

Updated AWS CLI base image:
FROM --platform=linux/amd64 amazon/aws-cli:2.9.1 → amazon/aws-cli:2.24.1

Updated Terraform version:
ENV TERRAFORM_VERSION=1.3.5 → 1.11.3

These changes ensure better support for the latest AWS services and Terraform modules, along with improved security and stability.